### PR TITLE
Fix bug in query builder join method (not complete solution)

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -532,6 +532,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		is_bool($escape) OR $escape = $this->_protect_identifiers;
 
 		// Split multiple conditions
+		$regex = "/([\(\)\[\]\w\.'-]+)(\s*[^\(\"\[`'\w]+\s*)(.+)/i";
+		
 		if ($escape === TRUE && preg_match_all('/\sAND\s|\sOR\s/i', $cond, $m, PREG_OFFSET_CAPTURE))
 		{
 			$newcond = '';
@@ -543,7 +545,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			{
 				$temp = substr($cond, $s, ($m[0][$i][1] - $s));
 
-				$newcond .= preg_match("/([\[\]\w\.'-]+)(\s*[^\"\[`'\w]+\s*)(.+)/i", $temp, $match)
+				$newcond .= preg_match($regex, $temp, $match)
 						? $this->protect_identifiers($match[1]).$match[2].$this->protect_identifiers($match[3])
 						: $temp;
 
@@ -553,7 +555,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$cond = ' ON '.$newcond;
 		}
 		// Split apart the condition and protect the identifiers
-		elseif ($escape === TRUE && preg_match("/([\[\]\w\.'-]+)(\s*[^\"\[`'\w]+\s*)(.+)/i", $cond, $match))
+		elseif ($escape === TRUE && preg_match($regex, $cond, $match))
 		{
 			$cond = ' ON '.$this->protect_identifiers($match[1]).$match[2].$this->protect_identifiers($match[3]);
 		}


### PR DESCRIPTION
If there are curved brackets in the join query, then the first bracket is removed and the second one is kept in some cases, which leads to an incorrect SQL statement. E.g.: 
<code>
    // Replace with a meaningful statement.
    $this->db->select("table2.field");
    $this->db->from("table1");
    $this->db->join("table2", "table1.id = table2.id  AND (table1.id = table2.id OR table1.id = table2.id)");
    $this->db->where("table1.id = 1");

```
$query = $this->db->get();

print_r($query->row_array());
```

</code>
generates the incorrect query: 
<code>
    ... ON `table1`.`id` = `table2`.`id` AND `table1`.`id` = `table2`.`id` OR `table1`.`id` = table2.id) WHERE ...
</code>

If the join is written like this
<code>
    $this->db->join("table2", "table1.id = table2.id  AND( table1.id = table2.id OR table1.id = table2.id)");
</code>
it works. 

The given solution is only a temporary solution! The given code now works. However, the following join
<code>
    $this->db->join("table2", "table1.id = table2.id  AND ( table1.id = table2.id OR table1.id = table2.id)");
</code>
does still not work as it generates the following query:
<code>
    ON `table1`.`id` = `table2`.`id` AND ( `table1`.`id =` `table2`.`id` OR `table1`.`id` = table2.id)
</code>
(error here: `id =`) Furthermore, the last table2.id is always not embraced by "`".

To solve the problem, the first added ( would be enough. However, I also added a ) and a second ( in the regex. It has be evaluated, if the the last two addtions are required. One has to dig deeper, to resolve the issue as an whole. I found the bug when migrating from CI 2 to CI 3. In CI2 the query is build correctly.
