### PR TITLE
Fix inconsitency in library loader

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1248,7 +1248,7 @@ class CI_Loader {
 		// Was a custom class name supplied? If so we'll use it
 		if (empty($object_name))
 		{
-			$object_name = strtolower($class);
+			$object_name = $class;
 			if (isset($this->_ci_varmap[$object_name]))
 			{
 				$object_name = $this->_ci_varmap[$object_name];


### PR DESCRIPTION
When loading a library, CodeIgniter shows inconsistent behaviour when assigning the property name:

```

class Tests extends CI_Controller {

    public function __construct() {
        parent::__construct();
    }

    public function index() {
        // Model Test.  Model file: application/models/SomeModel.php. Class name: SomeModel
        $this->load->model("SomeModel");
        $this->SomeModel->doSomething();  // Works fine.
        //$this->somemodel->doSomething(); // Does not work as expected.

        // Library test. Library file: application/libraries/SomeLibrary.php. Class name: SomeLibrary
        $this->load->library("SomeLibrary");
        $this->SomeLibrary->doSomething();    //  Throws an undefined property exception. However, does work for model classes.
        //$this->somelibrary->doSomething();   //  Does work, although both file and class name are in camel case.
    }
}

```
